### PR TITLE
Implements the Privacy API

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for tool_opencast.
+ *
+ * @package    tool_opencast
+ * @copyright  2018 Tamara Gunkel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_opencast\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy Subsystem for tool_opencast implementing null_provider.
+ *
+ * @copyright  2018 Tamara Gunkel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/tool_opencast.php
+++ b/lang/en/tool_opencast.php
@@ -47,3 +47,4 @@ $string['needphp55orhigher'] = 'PHP Version 5.5 or higher is needed';
 $string['wrongmimetypedetected'] = 'Wrong mimetype was detected, while trying to upload {$a->filename} from course {$a->coursename},
     You can only upload video files!';
 $string['serverconnectionerror'] = 'There was a problem with the connection to the opencast server. Please check your credentials and your network settings.';
+$string['privacy:metadata'] = 'The opencast tool only provides an API to communicate with an Opencast instance, but does not effect or store any personal data.';


### PR DESCRIPTION
I have implemented the Privacy API which is introduced in Moodle 3.5.
The tool does not store any personal data. Thus you only have to explain why the tool stores no data.