### PR TITLE
Disable request timeout for workflow creation requests

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1770,7 +1770,9 @@ class apibridge {
         $configuration = isset($params['configuration']) ? $params['configuration'] : [];
         $withoperations = isset($params['withoperations']) ? $params['withoperations'] : false;
         $withconfiguration = isset($params['withconfiguration']) ? $params['withconfiguration'] : false;
-        $response = $this->api->opencastapi->workflowsApi->run(
+        // The workflow might take awhile to start, especially if the Opencast system is under heavy load.
+        // Therefore, we set the timeout to 0 here to prevent timeouts of the request.
+        $response = $this->api->opencastapi->workflowsApi->setRequestTimeout(0)->run(
             $eventid,
             $workflow,
             $configuration,


### PR DESCRIPTION
Starting an Opencast workflow can take some time depending on the load of the system. Therefore, this disables the request timeout for workflow creation requests.

Also see https://github.com/Opencast-Moodle/moodle-block_opencast/pull/437