### PR TITLE
fix: reset mass action state per series to render checkboxes correctly

### DIFF
--- a/index.php
+++ b/index.php
@@ -444,6 +444,10 @@ foreach ($seriesvideodata as $series => $videodata) {
     }
 
     if ($videodata->error == 0) {
+        // Reset mass action state for this series iteration to ensure a previous
+        // empty series does not suppress checkboxes for subsequent series with videos.
+        $massaction->activate_massaction(true);
+
         $tableid = 'opencast-videos-table-' . $series;
         $table = $renderer->create_videos_tables($tableid, $headers, $columns, $baseurl);
         $deletedvideos = $DB->get_records("tool_opencast_deletejob", [], "", "opencasteventid");
@@ -643,7 +647,10 @@ foreach ($seriesvideodata as $series => $videodata) {
 
         // Last check to deactivate mass action, if there is nothing to display in the table.
         $activatedmassaction = !empty($rows);
-        $massaction->activate_massaction($activatedmassaction);
+        // Deactivate mass action only if there are no rows to display in this table.
+        if (!$activatedmassaction) {
+            $massaction->activate_massaction($activatedmassaction);
+        }
         $tablecontainerclasses = ['position-relative'];
         if ($activatedmassaction) {
             $tablecontainerclasses[] = massaction_helper::TABLE_CONTAINER_CLASSNAME;


### PR DESCRIPTION
When iterating over multiple series, an empty series would set the mass action state to false. Since the state was never reset, the next series with videos would not render checkboxes because the mass action was still deactivated from the previous iteration.

Fix: Reset mass action state to active at the start of each series iteration, and only deactivate it if the current table has no rows. This ensures that each series independently determines whether to render mass action checkboxes based on its own content.

Related to https://github.com/Opencast-Moodle/moodle-tool_opencast/issues/111